### PR TITLE
v2.1.1

### DIFF
--- a/compose.js
+++ b/compose.js
@@ -4,11 +4,8 @@
 
 	var chainFunction = require('./chain-function.js');
 
-	var compose = module.exports = (frontend, ...backend) => {
-		backend = chainFunction(...backend);
-		return (...args) =>
-			frontend(...backend(...args));
-	}
+	var compose = module.exports = (frontend, ...backend) =>
+		compose.mkargs(frontend, chainFunction(...backend));
 
 	compose.serial = (fn, ...fnlist) =>
 		fnlist.length ? compose(fn, compose.serial(...fnlist)) : fn;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "simple-function-utils",
 	"description": "A collection of small function utilities",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"author": "Hoàng Văn Khải <hvksmr1996@gmail.com>",
 	"contributors": [
 		"Hoàng Văn Khải <hvksmr1996@gmail.com>"


### PR DESCRIPTION
Improved `compose`:
- Before: `compose` depends on `chainFunction`
- After: `compose` depends on `compose.mkargs` and `chainFunction`
